### PR TITLE
fix: don't buffer reads

### DIFF
--- a/yamux.go
+++ b/yamux.go
@@ -55,6 +55,9 @@ func init() {
 	config.MaxStreamWindowSize = uint32(16 * 1024 * 1024)
 	// don't spam
 	config.LogOutput = ioutil.Discard
+	// We always run over a security transport that buffers internally
+	// (i.e., uses a block cipher).
+	config.ReadBufSize = 0
 	DefaultTransport = (*Transport)(config)
 }
 


### PR DESCRIPTION
This doesn't help when running over a security transport and allocates a bunch of memory.

cc @vyzo. Sorry, I was wrong, we shouldn't have enabled this.