### PR TITLE
update go-yamux to v2.0.0, use context passed to OpenStream

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/libp2p/go-libp2p-core/mux"
-	"github.com/libp2p/go-yamux"
+	"github.com/libp2p/go-yamux/v2"
 )
 
 // conn implements mux.MuxedConn over yamux.Session.
@@ -21,8 +21,8 @@ func (c *conn) IsClosed() bool {
 }
 
 // OpenStream creates a new stream.
-func (c *conn) OpenStream(context.Context) (mux.MuxedStream, error) {
-	s, err := c.yamux().OpenStream()
+func (c *conn) OpenStream(ctx context.Context) (mux.MuxedStream, error) {
+	s, err := c.yamux().OpenStream(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/libp2p/go-libp2p-core v0.8.0
 	github.com/libp2p/go-libp2p-testing v0.4.0
-	github.com/libp2p/go-yamux v1.4.1
+	github.com/libp2p/go-yamux/v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/libp2p/go-libp2p-testing v0.4.0/go.mod h1:Q+PFXYoiYFN5CAEG2w3gLPEzotl
 github.com/libp2p/go-maddr-filter v0.1.0/go.mod h1:VzZhTXkMucEGGEOSKddrwGiOv0tUhgnKqNEmIAz/bPU=
 github.com/libp2p/go-msgio v0.0.6/go.mod h1:4ecVB6d9f4BDSL5fqvPiC4A3KivjWn+Venn/1ALLMWA=
 github.com/libp2p/go-openssl v0.0.7/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
-github.com/libp2p/go-yamux v1.4.1 h1:P1Fe9vF4th5JOxxgQvfbOHkrGqIZniTLf+ddhZp8YTI=
-github.com/libp2p/go-yamux v1.4.1/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
+github.com/libp2p/go-yamux/v2 v2.0.0 h1:vSGhAy5u6iHBq11ZDcyHH4Blcf9xlBhT4WQDoOE90LU=
+github.com/libp2p/go-yamux/v2 v2.0.0/go.mod h1:NVWira5+sVUIU6tu1JWvaRn1dRnG+cawOJiflsAM+7U=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=

--- a/stream.go
+++ b/stream.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/mux"
-	"github.com/libp2p/go-yamux"
+	"github.com/libp2p/go-yamux/v2"
 )
 
 // stream implements mux.MuxedStream over yamux.Stream.

--- a/transport.go
+++ b/transport.go
@@ -5,7 +5,7 @@ import (
 	"net"
 
 	mux "github.com/libp2p/go-libp2p-core/mux"
-	yamux "github.com/libp2p/go-yamux"
+	"github.com/libp2p/go-yamux/v2"
 )
 
 var DefaultTransport *Transport


### PR DESCRIPTION
Fixes #30.

Looks like the v2 of go-yamux update actually succeeded. Still feeling weird about the changed import path, but that's how it's supposed to work.